### PR TITLE
Add opt-out REST endpoints and service to disable sending stats

### DIFF
--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsClusterPeriodical.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsClusterPeriodical.java
@@ -93,7 +93,7 @@ public class UsageStatsClusterPeriodical extends UsageStatsPeriodical {
 
     @Override
     public boolean startOnThisNode() {
-        return config.isEnabled()
+        return isEnabled()
                 && serverStatus.hasCapability(ServerStatus.Capability.MASTER)
                 && !serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE);
     }

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsClusterPeriodical.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsClusterPeriodical.java
@@ -93,7 +93,7 @@ public class UsageStatsClusterPeriodical extends UsageStatsPeriodical {
 
     @Override
     public boolean startOnThisNode() {
-        return isEnabled()
+        return config.isEnabled()
                 && serverStatus.hasCapability(ServerStatus.Capability.MASTER)
                 && !serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE);
     }

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsConstants.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsConstants.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 Graylog, Inc. (hello@graylog.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graylog.plugins.usagestatistics;
+
+import com.squareup.okhttp.MediaType;
+import org.graylog2.plugin.Version;
+
+public class UsageStatsConstants {
+    public static final MediaType CONTENT_TYPE = MediaType.parse("application/x-jackson-smile");
+    public static final String USAGE_STATS_VERSION = UsageStatsMetaData.VERSION.toString();
+    public static final String USER_AGENT = "Graylog " + Version.CURRENT_CLASSPATH;
+}

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsModule.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsModule.java
@@ -55,6 +55,7 @@ public class UsageStatsModule extends PluginModule {
         addPeriodical(UsageStatsNodePeriodical.class);
         addPeriodical(UsageStatsClusterPeriodical.class);
         addRestResource(UsageStatsResource.class);
+        addRestResource(UsageStatsOptOutResource.class);
 
         addConfigBeans();
     }

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsNodePeriodical.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsNodePeriodical.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 @Singleton
@@ -103,7 +102,7 @@ public class UsageStatsNodePeriodical extends UsageStatsPeriodical {
 
     @Override
     public boolean startOnThisNode() {
-        return config.isEnabled() && !serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE);
+        return isEnabled() && !serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE);
     }
 
     @Override

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsNodePeriodical.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsNodePeriodical.java
@@ -102,7 +102,7 @@ public class UsageStatsNodePeriodical extends UsageStatsPeriodical {
 
     @Override
     public boolean startOnThisNode() {
-        return isEnabled() && !serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE);
+        return config.isEnabled() && !serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE);
     }
 
     @Override

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -24,7 +24,9 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -55,13 +57,20 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
     }
 
     @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Timed
     @ApiOperation(value = "Disable sending anonymous usage stats")
     @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Missing or invalid opt-out state"),
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
-    public Response optOut() {
-        usageStatsOptOutService.createOptOut();
+    public Response optOut(@Nullable UsageStatsOptOutState optOutState) {
+        if (optOutState == null) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+
+        usageStatsOptOutService.createOptOut(optOutState);
 
         return Response.noContent().build();
     }

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 Graylog, Inc. (hello@graylog.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graylog.plugins.usagestatistics;
+
+import com.codahale.metrics.annotation.Timed;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.plugin.rest.PluginRestResource;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@RequiresAuthentication
+@Api(value = "Usage Statistics Opt-Out", description = "Anonymous usage statistics opt-out state of this Graylog setup")
+@Path("/opt-out")
+public class UsageStatsOptOutResource extends RestResource implements PluginRestResource {
+    private final UsageStatsOptOutService usageStatsOptOutService;
+
+    @Inject
+    public UsageStatsOptOutResource(UsageStatsOptOutService usageStatsOptOutService) {
+        this.usageStatsOptOutService = usageStatsOptOutService;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    @ApiOperation(value = "Get opt-out status")
+    @ApiResponses(value = {
+            @ApiResponse(code = 500, message = "Internal Server Error")
+    })
+    public UsageStatsOptOutState getOptOutStatus() {
+        return usageStatsOptOutService.getOptOutState();
+    }
+
+    @POST
+    @Timed
+    @ApiOperation(value = "Disable sending anonymous usage stats")
+    @ApiResponses(value = {
+            @ApiResponse(code = 500, message = "Internal Server Error")
+    })
+    public Response optOut() {
+        usageStatsOptOutService.createOptOut();
+
+        return Response.noContent().build();
+    }
+}

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -53,7 +53,7 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
     @ApiResponses(value = {
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
-    public UsageStatsOptOutState getOptOutStatus() {
+    public UsageStatsOptOutState getOptOutState() {
         return usageStatsOptOutService.getOptOutState();
     }
 
@@ -66,7 +66,7 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
             @ApiResponse(code = 400, message = "Missing or invalid opt-out state"),
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
-    public Response optOut(@Valid @NotNull UsageStatsOptOutState optOutState) {
+    public Response setOptOutState(@Valid @NotNull UsageStatsOptOutState optOutState) {
         usageStatsOptOutService.createOptOut(optOutState);
 
         return Response.noContent().build();

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -66,6 +66,6 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
     public void setOptOutState(@Valid @NotNull UsageStatsOptOutState optOutState) {
-        usageStatsOptOutService.createOptOut(optOutState);
+        usageStatsOptOutService.setOptOutState(optOutState);
     }
 }

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -24,8 +24,9 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -65,11 +66,7 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
             @ApiResponse(code = 400, message = "Missing or invalid opt-out state"),
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
-    public Response optOut(@Nullable UsageStatsOptOutState optOutState) {
-        if (optOutState == null) {
-            return Response.status(Response.Status.BAD_REQUEST).build();
-        }
-
+    public Response optOut(@Valid @NotNull UsageStatsOptOutState optOutState) {
         usageStatsOptOutService.createOptOut(optOutState);
 
         return Response.noContent().build();

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -33,7 +33,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 @RequiresAuthentication
 @Api(value = "Usage Statistics Opt-Out", description = "Anonymous usage statistics opt-out state of this Graylog setup")
@@ -66,9 +65,7 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
             @ApiResponse(code = 400, message = "Missing or invalid opt-out state"),
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
-    public Response setOptOutState(@Valid @NotNull UsageStatsOptOutState optOutState) {
+    public void setOptOutState(@Valid @NotNull UsageStatsOptOutState optOutState) {
         usageStatsOptOutService.createOptOut(optOutState);
-
-        return Response.noContent().build();
     }
 }

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
@@ -72,9 +72,7 @@ public class UsageStatsOptOutService {
     }
 
     public UsageStatsOptOutState getOptOutState() {
-        final UsageStatsOptOutState optOutState = clusterConfigService.get(UsageStatsOptOutState.class);
-
-        return optOutState == null ? UsageStatsOptOutState.create(false) : optOutState;
+        return clusterConfigService.getOrDefault(UsageStatsOptOutState.class, UsageStatsOptOutState.create(false));
     }
 
     public void createOptOut() {
@@ -134,6 +132,7 @@ public class UsageStatsOptOutService {
         }
     }
 
+    @Nullable
     protected byte[] buildPayload() {
         try {
             return objectMapper.writeValueAsBytes(ImmutableMap.<String, String>builder().build());

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2015 Graylog, Inc. (hello@graylog.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graylog.plugins.usagestatistics;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
+import org.graylog.plugins.usagestatistics.providers.SmileObjectMapper;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.cluster.ClusterId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static org.graylog.plugins.usagestatistics.UsageStatsConstants.CONTENT_TYPE;
+import static org.graylog.plugins.usagestatistics.UsageStatsConstants.USAGE_STATS_VERSION;
+import static org.graylog.plugins.usagestatistics.UsageStatsConstants.USER_AGENT;
+
+public class UsageStatsOptOutService {
+    private static final Logger LOG = LoggerFactory.getLogger(UsageStatsOptOutService.class);
+
+    private final ClusterConfigService clusterConfigService;
+    private final UsageStatsConfiguration config;
+    private final Executor executor;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public UsageStatsOptOutService(ClusterConfigService clusterConfigService,
+                                   UsageStatsConfiguration config,
+                                   OkHttpClient httpClient,
+                                   @SmileObjectMapper ObjectMapper objectMapper) {
+        this(clusterConfigService, config, httpClient, objectMapper, Executors.newSingleThreadExecutor());
+    }
+
+    protected UsageStatsOptOutService(ClusterConfigService clusterConfigService,
+                                      UsageStatsConfiguration config,
+                                      OkHttpClient httpClient,
+                                      ObjectMapper objectMapper,
+                                      Executor executor) {
+        this.clusterConfigService = clusterConfigService;
+        this.config = config;
+        this.executor = executor;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public UsageStatsOptOutState getOptOutState() {
+        final UsageStatsOptOutState optOutState = clusterConfigService.get(UsageStatsOptOutState.class);
+
+        return optOutState == null ? UsageStatsOptOutState.create(false) : optOutState;
+    }
+
+    public void createOptOut() {
+        // Run the opt-out request outside of the calling thread so it does not block.
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                clusterConfigService.write(UsageStatsOptOutState.create(true));
+
+                final URL url = getUrl();
+
+                if (url == null) {
+                    LOG.debug("Not sending opt-out request, 'usage_statistics_url' is not set.");
+                    return;
+                }
+
+                final Headers headers = new Headers.Builder()
+                        .add(HttpHeaders.USER_AGENT, USER_AGENT)
+                        .add("X-Usage-Statistics-Version", USAGE_STATS_VERSION)
+                        .build();
+
+                final Request request = new Request.Builder()
+                        .url(url)
+                        .headers(headers)
+                        .post(RequestBody.create(CONTENT_TYPE, buildPayload()))
+                        .build();
+
+                final Response response;
+                try {
+                    response = httpClient.newCall(request).execute();
+                } catch (IOException e) {
+                    LOG.error("Error while sending anonymous usage statistics opt-out");
+                    LOG.debug("Error details", e);
+                    return;
+                }
+
+                if (!response.isSuccessful()) {
+                    LOG.warn("Couldn't successfully send usage statistics opt-out: {}", response);
+                }
+            }
+        });
+    }
+
+    @Nullable
+    protected URL getUrl() {
+        final ClusterId clusterId = clusterConfigService.get(ClusterId.class);
+
+        if (clusterId != null) {
+            return HttpUrl.get(config.getUrl()).newBuilder()
+                    .addPathSegment("cluster")
+                    .addPathSegment(clusterId.clusterId())
+                    .addPathSegment("optout")
+                    .build()
+                    .url();
+        } else {
+            return null;
+        }
+    }
+
+    protected byte[] buildPayload() {
+        try {
+            return objectMapper.writeValueAsBytes(ImmutableMap.<String, String>builder().build());
+        } catch (JsonProcessingException e) {
+            LOG.error("Error while serializing usage statistics data", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
@@ -64,7 +64,7 @@ public class UsageStatsOptOutService {
         return clusterConfigService.getOrDefault(UsageStatsOptOutState.class, UsageStatsOptOutState.create(false));
     }
 
-    public void createOptOut(final UsageStatsOptOutState optOutState) {
+    public void setOptOutState(final UsageStatsOptOutState optOutState) {
         if (optOutState == null) {
             return;
         }

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
@@ -75,12 +75,21 @@ public class UsageStatsOptOutService {
         return clusterConfigService.getOrDefault(UsageStatsOptOutState.class, UsageStatsOptOutState.create(false));
     }
 
-    public void createOptOut() {
+    public void createOptOut(final UsageStatsOptOutState optOutState) {
+        if (optOutState == null) {
+            return;
+        }
+        if (!optOutState.isOptOut()) {
+            LOG.debug("Disable opt-out in cluster config");
+            clusterConfigService.write(optOutState);
+            return;
+        }
+
         // Run the opt-out request outside of the calling thread so it does not block.
         executor.execute(new Runnable() {
             @Override
             public void run() {
-                clusterConfigService.write(UsageStatsOptOutState.create(true));
+                clusterConfigService.write(optOutState);
 
                 final URL url = getUrl();
 

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutState.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutState.java
@@ -23,7 +23,7 @@ import com.google.auto.value.AutoValue;
 @JsonAutoDetect
 @AutoValue
 public abstract class UsageStatsOptOutState {
-    @JsonProperty
+    @JsonProperty("opt_out")
     public abstract boolean isOptOut();
 
     @JsonCreator

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutState.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutState.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Graylog, Inc. (hello@graylog.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graylog.plugins.usagestatistics;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class UsageStatsOptOutState {
+    @JsonProperty
+    public abstract boolean isOptOut();
+
+    @JsonCreator
+    public static UsageStatsOptOutState create(@JsonProperty("opt_out") boolean isOptOut) {
+        return new AutoValue_UsageStatsOptOutState(isOptOut);
+    }
+}

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsPeriodical.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsPeriodical.java
@@ -76,9 +76,10 @@ public abstract class UsageStatsPeriodical extends Periodical {
             return false;
         }
 
-        final UsageStatsOptOutState optOutState = clusterConfigService.get(UsageStatsOptOutState.class);
+        final UsageStatsOptOutState state = clusterConfigService.getOrDefault(UsageStatsOptOutState.class,
+                UsageStatsOptOutState.create(false));
 
-        return optOutState == null || !optOutState.isOptOut();
+        return !state.isOptOut();
     }
 
     @Override

--- a/src/test/java/org/graylog/plugins/usagestatistics/TestClusterConfigService.java
+++ b/src/test/java/org/graylog/plugins/usagestatistics/TestClusterConfigService.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Graylog, Inc. (hello@graylog.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graylog.plugins.usagestatistics;
+
+import org.assertj.core.util.Maps;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.shared.utilities.AutoValueUtils;
+
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+public class TestClusterConfigService implements ClusterConfigService {
+    private final Map<String, Object> data = Maps.newConcurrentHashMap();
+
+    @SuppressWarnings("unchecked")
+    public <T> T get(Class<T> type) {
+        return (T) data.get(type.getCanonicalName());
+    }
+
+    @Override
+    public <T> T getOrDefault(Class<T> type, T defaultValue) {
+        return firstNonNull(get(type), defaultValue);
+    }
+
+    @Override
+    public <T> void write(T payload) {
+        data.put(AutoValueUtils.getCanonicalName(payload.getClass()), payload);
+    }
+
+    public <T> void remove(Class<T> type) {
+        data.remove(type.getCanonicalName());
+    }
+
+    public void clear() {
+        data.clear();
+    }
+}

--- a/src/test/java/org/graylog/plugins/usagestatistics/TestClusterConfigService.java
+++ b/src/test/java/org/graylog/plugins/usagestatistics/TestClusterConfigService.java
@@ -15,7 +15,7 @@
  */
 package org.graylog.plugins.usagestatistics;
 
-import org.assertj.core.util.Maps;
+import com.google.common.collect.Maps;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.shared.utilities.AutoValueUtils;
 
@@ -24,7 +24,7 @@ import java.util.Map;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class TestClusterConfigService implements ClusterConfigService {
-    private final Map<String, Object> data = Maps.newConcurrentHashMap();
+    private final Map<String, Object> data = Maps.newConcurrentMap();
 
     @SuppressWarnings("unchecked")
     public <T> T get(Class<T> type) {

--- a/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsClusterPeriodicalTest.java
+++ b/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsClusterPeriodicalTest.java
@@ -91,16 +91,38 @@ public class UsageStatsClusterPeriodicalTest {
         when(configuration.isEnabled()).thenReturn(false);
         when(serverStatus.hasCapability(ServerStatus.Capability.MASTER)).thenReturn(false);
         when(serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE)).thenReturn(true);
+        assertThat(periodical.startOnThisNode()).isFalse();
 
         when(configuration.isEnabled()).thenReturn(false);
         when(serverStatus.hasCapability(ServerStatus.Capability.MASTER)).thenReturn(false);
         when(serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE)).thenReturn(false);
         assertThat(periodical.startOnThisNode()).isFalse();
+    }
+
+    @Test
+    public void testIsEnabled() throws Exception {
+        when(configuration.isEnabled()).thenReturn(true);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(null);
+        assertThat(periodical.isEnabled()).isTrue();
 
         when(configuration.isEnabled()).thenReturn(true);
-        when(serverStatus.hasCapability(ServerStatus.Capability.MASTER)).thenReturn(true);
-        when(serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE)).thenReturn(false);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(false));
+        assertThat(periodical.isEnabled()).isTrue();
+
+        when(configuration.isEnabled()).thenReturn(false);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(null);
+        assertThat(periodical.isEnabled()).isFalse();
+
+        when(configuration.isEnabled()).thenReturn(false);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(false));
+        assertThat(periodical.isEnabled()).isFalse();
+
+        when(configuration.isEnabled()).thenReturn(true);
         when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(true));
-        assertThat(periodical.startOnThisNode()).isFalse();
+        assertThat(periodical.isEnabled()).isFalse();
+
+        when(configuration.isEnabled()).thenReturn(false);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(true));
+        assertThat(periodical.isEnabled()).isFalse();
     }
 }

--- a/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsNodePeriodicalTest.java
+++ b/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsNodePeriodicalTest.java
@@ -88,10 +88,32 @@ public class UsageStatsNodePeriodicalTest {
         when(configuration.isEnabled()).thenReturn(false);
         when(serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE)).thenReturn(true);
         assertThat(periodical.startOnThisNode()).isFalse();
+    }
+
+    @Test
+    public void testIsEnabled() throws Exception {
+        when(configuration.isEnabled()).thenReturn(true);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(null);
+        assertThat(periodical.isEnabled()).isTrue();
 
         when(configuration.isEnabled()).thenReturn(true);
-        when(serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE)).thenReturn(false);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(false));
+        assertThat(periodical.isEnabled()).isTrue();
+
+        when(configuration.isEnabled()).thenReturn(false);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(null);
+        assertThat(periodical.isEnabled()).isFalse();
+
+        when(configuration.isEnabled()).thenReturn(false);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(false));
+        assertThat(periodical.isEnabled()).isFalse();
+
+        when(configuration.isEnabled()).thenReturn(true);
         when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(true));
-        assertThat(periodical.startOnThisNode()).isFalse();
+        assertThat(periodical.isEnabled()).isFalse();
+
+        when(configuration.isEnabled()).thenReturn(false);
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(true));
+        assertThat(periodical.isEnabled()).isFalse();
     }
 }

--- a/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutServiceTest.java
+++ b/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutServiceTest.java
@@ -97,7 +97,7 @@ public class UsageStatsOptOutServiceTest {
     public void testCreateOptOut() throws Exception {
         webserver.enqueue(OPT_OUT_RESPONSE);
 
-        optOutService.createOptOut(UsageStatsOptOutState.create(true));
+        optOutService.setOptOutState(UsageStatsOptOutState.create(true));
 
         assertThat(webserver.getRequestCount()).isEqualTo(1);
 
@@ -117,7 +117,7 @@ public class UsageStatsOptOutServiceTest {
 
         webserver.enqueue(OPT_OUT_RESPONSE);
 
-        optOutService.createOptOut(UsageStatsOptOutState.create(false));
+        optOutService.setOptOutState(UsageStatsOptOutState.create(false));
 
         assertThat(webserver.getRequestCount()).isEqualTo(0);
         assertThat(clusterConfigService.get(UsageStatsOptOutState.class)).isEqualTo(UsageStatsOptOutState.create(false));
@@ -127,7 +127,7 @@ public class UsageStatsOptOutServiceTest {
     public void testCreateOptOutWithNullParam() throws Exception {
         webserver.enqueue(OPT_OUT_RESPONSE);
 
-        optOutService.createOptOut(null);
+        optOutService.setOptOutState(null);
 
         assertThat(webserver.getRequestCount()).isEqualTo(0);
         assertThat(clusterConfigService.get(UsageStatsOptOutState.class)).isNull();
@@ -137,7 +137,7 @@ public class UsageStatsOptOutServiceTest {
     public void testCreateOptOutWithNullClusterId() throws Exception {
         clusterConfigService.remove(ClusterId.class);
 
-        optOutService.createOptOut(UsageStatsOptOutState.create(true));
+        optOutService.setOptOutState(UsageStatsOptOutState.create(true));
 
         assertThat(webserver.getRequestCount()).isEqualTo(0);
     }

--- a/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutServiceTest.java
+++ b/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutServiceTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2015 Graylog, Inc. (hello@graylog.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graylog.plugins.usagestatistics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import org.graylog.plugins.usagestatistics.providers.SmileObjectMapperProvider;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.cluster.ClusterId;
+import org.graylog2.shared.bindings.providers.OkHttpClientProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.plugins.usagestatistics.UsageStatsConstants.USAGE_STATS_VERSION;
+import static org.graylog.plugins.usagestatistics.UsageStatsConstants.USER_AGENT;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UsageStatsOptOutServiceTest {
+    public static final MockResponse OPT_OUT_RESPONSE = new MockResponse().setResponseCode(202);
+
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    private UsageStatsConfiguration configSpy = spy(new UsageStatsConfiguration());
+    private ObjectMapper objectMapper = new SmileObjectMapperProvider().get();
+    private UsageStatsOptOutService optOutService;
+    private MockWebServer webserver = new MockWebServer();
+    private final OkHttpClientProvider clientProvider = new OkHttpClientProvider(
+            Duration.seconds(1L),
+            Duration.seconds(1L),
+            Duration.seconds(1L),
+            null);
+
+    @Before
+    public void setUp() throws Exception {
+        webserver.start();
+
+        when(clusterConfigService.get(ClusterId.class)).thenReturn(ClusterId.create("test-cluster-id"));
+        when(configSpy.getUrl()).thenReturn(webserver.url("/submit/").uri());
+
+        this.optOutService = new UsageStatsOptOutService(clusterConfigService,
+                configSpy, clientProvider.get(), objectMapper, MoreExecutors.newDirectExecutorService());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        webserver.shutdown();
+    }
+
+    @Test
+    public void testGetOptOutState() throws Exception {
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(null);
+        assertThat(optOutService.getOptOutState().isOptOut()).isFalse();
+
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(false));
+        assertThat(optOutService.getOptOutState().isOptOut()).isFalse();
+
+        when(clusterConfigService.get(UsageStatsOptOutState.class)).thenReturn(UsageStatsOptOutState.create(true));
+        assertThat(optOutService.getOptOutState().isOptOut()).isTrue();
+    }
+
+    @Test
+    public void testCreateOptOut() throws Exception {
+        webserver.enqueue(OPT_OUT_RESPONSE);
+
+        optOutService.createOptOut();
+
+        assertThat(webserver.getRequestCount()).isEqualTo(1);
+
+        final RecordedRequest request = webserver.takeRequest(10, TimeUnit.SECONDS);
+
+        assertThat(request.getBody().readByteArray())
+                .isEqualTo(objectMapper.writeValueAsBytes(ImmutableMap.<String, String>builder().build()));
+        assertThat(request.getHeader("X-Usage-Statistics-Version")).isEqualTo(USAGE_STATS_VERSION);
+        assertThat(request.getHeader(HttpHeaders.USER_AGENT)).isEqualTo(USER_AGENT);
+    }
+
+    @Test
+    public void testCreateOptOutWithNullClusterId() throws Exception {
+        when(clusterConfigService.get(ClusterId.class)).thenReturn(null);
+
+        optOutService.createOptOut();
+
+        assertThat(webserver.getRequestCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testGetUrlDefault() throws Exception {
+        // Make sure we get the real default URL.
+        Mockito.reset(configSpy);
+
+        assertThat(optOutService.getUrl().toString())
+                .isEqualTo("https://stats-collector.graylog.com/submit/cluster/test-cluster-id/optout");
+    }
+
+    @Test
+    public void testGetUrlWithoutClusterId() throws Exception {
+        when(clusterConfigService.get(ClusterId.class)).thenReturn(null);
+
+        assertThat(optOutService.getUrl()).isNull();
+    }
+}


### PR DESCRIPTION
The UsageStatsOptOutResource has one endpoint to check the current
opt-out status and a second one to submit the opt-out. The opt-out
status is persisted in the cluster config so it is available on all
nodes.

The Node and Cluster periodicals now check on every run if sending
stats is enabled.

Fixes #1
