### PR TITLE
Opt out extension

### DIFF
--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -56,6 +56,7 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
     @Timed
     @ApiOperation(value = "Get opt-out status")
     @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Opt-out status does not exist"),
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
     public UsageStatsOptOutState getOptOutState() {

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -35,10 +35,15 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import static org.graylog2.shared.security.RestPermissions.CLUSTER_CONFIG_ENTRY_CREATE;
+import static org.graylog2.shared.security.RestPermissions.CLUSTER_CONFIG_ENTRY_READ;
+
 @RequiresAuthentication
 @Api(value = "Usage Statistics Opt-Out", description = "Anonymous usage statistics opt-out state of this Graylog setup")
 @Path("/opt-out")
 public class UsageStatsOptOutResource extends RestResource implements PluginRestResource {
+    private static final String CLUSTER_CONFIG_INSTANCE = UsageStatsOptOutState.class.getCanonicalName();
+
     private final UsageStatsOptOutService usageStatsOptOutService;
 
     @Inject
@@ -54,6 +59,8 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
     public UsageStatsOptOutState getOptOutState() {
+        checkPermission(CLUSTER_CONFIG_ENTRY_READ, CLUSTER_CONFIG_INSTANCE);
+
         final UsageStatsOptOutState optOutState = usageStatsOptOutService.getOptOutState();
 
         if (optOutState == null) {
@@ -73,6 +80,8 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
     public void setOptOutState(@Valid @NotNull UsageStatsOptOutState optOutState) {
+        checkPermission(CLUSTER_CONFIG_ENTRY_CREATE, CLUSTER_CONFIG_INSTANCE);
+
         usageStatsOptOutService.setOptOutState(optOutState);
     }
 }

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutResource.java
@@ -29,6 +29,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -53,7 +54,13 @@ public class UsageStatsOptOutResource extends RestResource implements PluginRest
             @ApiResponse(code = 500, message = "Internal Server Error")
     })
     public UsageStatsOptOutState getOptOutState() {
-        return usageStatsOptOutService.getOptOutState();
+        final UsageStatsOptOutState optOutState = usageStatsOptOutService.getOptOutState();
+
+        if (optOutState == null) {
+            throw new NotFoundException();
+        }
+
+        return optOutState;
     }
 
     @POST

--- a/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutService.java
@@ -60,8 +60,9 @@ public class UsageStatsOptOutService {
         this.objectMapper = objectMapper;
     }
 
+    @Nullable
     public UsageStatsOptOutState getOptOutState() {
-        return clusterConfigService.getOrDefault(UsageStatsOptOutState.class, UsageStatsOptOutState.create(false));
+        return clusterConfigService.get(UsageStatsOptOutState.class);
     }
 
     public void setOptOutState(final UsageStatsOptOutState optOutState) {

--- a/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutServiceTest.java
+++ b/src/test/java/org/graylog/plugins/usagestatistics/UsageStatsOptOutServiceTest.java
@@ -84,7 +84,7 @@ public class UsageStatsOptOutServiceTest {
     @Test
     public void testGetOptOutState() throws Exception {
         clusterConfigService.clear();
-        assertThat(optOutService.getOptOutState().isOptOut()).isFalse();
+        assertThat(optOutService.getOptOutState()).isNull();
 
         clusterConfigService.write(UsageStatsOptOutState.create(false));
         assertThat(optOutService.getOptOutState().isOptOut()).isFalse();


### PR DESCRIPTION
- Return a 404 if no opt-out state has been created. This is needed to be able to differentiate between opt-out, opt-in and "no decision".
- Check permissions in the opt-out resource.
