### PR TITLE
additional statistics for alarm callbacks and alert counts

### DIFF
--- a/src/main/java/org/graylog/plugins/usagestatistics/collectors/ClusterCollector.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/collectors/ClusterCollector.java
@@ -19,6 +19,7 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.ImmutableMap;
 import org.cliffc.high_scale_lib.Counter;
 import org.graylog.plugins.usagestatistics.UsageStatsMetaData;
+import org.graylog.plugins.usagestatistics.dto.AlarmStats;
 import org.graylog.plugins.usagestatistics.dto.ClusterDataSet;
 import org.graylog.plugins.usagestatistics.dto.ClusterStats;
 import org.graylog.plugins.usagestatistics.dto.LdapStats;
@@ -99,7 +100,8 @@ public class ClusterCollector {
                 clusterStats.contentPackCount(),
                 counts.total(),
                 buildStreamThroughput(),
-                buildLdapStats()
+                buildLdapStats(),
+                buildAlarmStats()
         );
     }
 
@@ -125,5 +127,10 @@ public class ClusterCollector {
                                 ldapStats.activeDirectory(),
                                 ldapStats.roleMappingCount(),
                                 ldapStats.roleCount());
+    }
+
+    private AlarmStats buildAlarmStats() {
+        final org.graylog2.system.stats.AlarmStats stats = clusterStatsService.alarmStats();
+        return AlarmStats.create(stats.alertCount(), stats.alarmcallbackCountByType());
     }
 }

--- a/src/main/java/org/graylog/plugins/usagestatistics/dto/AlarmStats.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/dto/AlarmStats.java
@@ -1,0 +1,21 @@
+package org.graylog.plugins.usagestatistics.dto;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class AlarmStats {
+    @JsonProperty
+    public abstract long alertCount();
+
+    @JsonProperty
+    public abstract Map<String, Long> alarmcallbackCountByType();
+
+    public static AlarmStats create(long alertCount, Map<String, Long> alarmcallbackCountByType) {
+        return new AutoValue_AlarmStats(alertCount, alarmcallbackCountByType);
+    }
+}

--- a/src/main/java/org/graylog/plugins/usagestatistics/dto/AlarmStats.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/dto/AlarmStats.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Graylog, Inc. (hello@graylog.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.graylog.plugins.usagestatistics.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/src/main/java/org/graylog/plugins/usagestatistics/dto/ClusterStats.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/dto/ClusterStats.java
@@ -46,7 +46,8 @@ public abstract class ClusterStats {
                                       long contentPackCount,
                                       long totalMessages,
                                       Map<String, Long> streamThroughput,
-                                      LdapStats ldapStats
+                                      LdapStats ldapStats,
+                                      AlarmStats alarmStats
     ) {
         return new AutoValue_ClusterStats(
                 elasticsearchCluster,
@@ -68,7 +69,8 @@ public abstract class ClusterStats {
                 contentPackCount,
                 totalMessages,
                 streamThroughput,
-                ldapStats);
+                ldapStats,
+                alarmStats);
     }
 
     @JsonProperty
@@ -130,4 +132,7 @@ public abstract class ClusterStats {
 
     @JsonProperty
     public abstract LdapStats ldapStats();
+
+    @JsonProperty
+    public abstract AlarmStats alarmStats();
 }


### PR DESCRIPTION
- uses mongodb aggregation for group by, should be available starting with mongodb v2.2 but we need to verify

Depends on Graylog2/graylog2-server#1537
