### PR TITLE
Using JestClient to retrieve ES cluster details.

### DIFF
--- a/src/main/java/org/graylog/plugins/usagestatistics/collectors/ElasticsearchCollector.java
+++ b/src/main/java/org/graylog/plugins/usagestatistics/collectors/ElasticsearchCollector.java
@@ -16,15 +16,12 @@
  */
 package org.graylog.plugins.usagestatistics.collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
-import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
-import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
-import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.ClusterAdminClient;
-import org.elasticsearch.monitor.jvm.JvmStats;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.cluster.NodesInfo;
 import org.graylog.plugins.usagestatistics.dto.HostInfo;
 import org.graylog.plugins.usagestatistics.dto.JvmInfo;
 import org.graylog.plugins.usagestatistics.dto.MacAddress;
@@ -33,97 +30,109 @@ import org.graylog.plugins.usagestatistics.dto.elasticsearch.ElasticsearchCluste
 import org.graylog.plugins.usagestatistics.dto.elasticsearch.ElasticsearchNodeInfo;
 import org.graylog.plugins.usagestatistics.dto.elasticsearch.IndicesStats;
 import org.graylog.plugins.usagestatistics.dto.elasticsearch.NodesStats;
+import org.graylog2.indexer.gson.GsonUtils;
 import org.graylog2.system.stats.ClusterStatsService;
 import org.graylog2.system.stats.elasticsearch.ElasticsearchStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class ElasticsearchCollector {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchCollector.class);
 
-    private final Client client;
     private final ClusterStatsService clusterStatsService;
+    private final JestClient jestClient;
 
     @Inject
-    public ElasticsearchCollector(Client client, ClusterStatsService clusterStatsService) {
-        this.client = client;
+    public ElasticsearchCollector(ClusterStatsService clusterStatsService, JestClient jestClient) {
         this.clusterStatsService = clusterStatsService;
+        this.jestClient = jestClient;
     }
 
     public Set<ElasticsearchNodeInfo> getNodeInfos() {
-        final Map<String, NodeInfo> nodeInfos = fetchNodeInfos();
-        final Map<String, NodeStats> nodeStats = fetchNodeStats();
-
-        final Set<ElasticsearchNodeInfo> elasticsearchNodeInfos = Sets.newHashSetWithExpectedSize(nodeInfos.size());
-        for (String node : nodeInfos.keySet()) {
-            final NodeInfo info = nodeInfos.get(node);
-            final NodeStats stats = nodeStats.get(node);
-
-            if (info == null || stats == null) {
-                LOG.warn("Couldn't retrieve all required information from Elasticsearch node {}, skipping.", node);
-                continue;
-            }
-
-            // TODO remove these as soon as the backend service treats HostInfo as optional
-            // the host info details aren't available in Elasticsearch 2.x anymore, but we still report the empty
-            // bean because the backend service still expects some data (even if it is empty)
-            final MacAddress macAddress = MacAddress.EMPTY;
-            final HostInfo.Cpu cpu = null;
-            final HostInfo.Memory memory = null;
-            final HostInfo.Memory swap =  null;
-            final HostInfo hostInfo = HostInfo.create(macAddress, cpu, memory, swap);
-
-            final List<String> garbageCollectors;
-            if (stats.getJvm() != null) {
-                garbageCollectors = Lists.newArrayList();
-                for (JvmStats.GarbageCollector gc : stats.getJvm().getGc()) {
-                    garbageCollectors.add(gc.getName());
-                }
-            } else {
-                garbageCollectors = Collections.emptyList();
-            }
-
-            final JvmInfo jvmInfo;
-            if (info.getJvm() != null) {
-                final JvmInfo.Memory jvmMemory = JvmInfo.Memory.create(
-                        info.getJvm().getMem().getHeapInit().bytes(),
-                        info.getJvm().getMem().getHeapMax().bytes(),
-                        info.getJvm().getMem().getNonHeapInit().bytes(),
-                        info.getJvm().getMem().getNonHeapMax().bytes(),
-                        info.getJvm().getMem().getDirectMemoryMax().bytes()
-                );
-                final JvmInfo.Os jvmOs = JvmInfo.Os.create(
-                        info.getJvm().getSystemProperties().get("os.name"),
-                        info.getJvm().getSystemProperties().get("os.version"),
-                        info.getJvm().getSystemProperties().get("os.arch")
-                );
-                jvmInfo = JvmInfo.create(
-                        info.getJvm().version(),
-                        info.getJvm().getVmName(),
-                        info.getJvm().getVmVersion(),
-                        info.getJvm().getVmVendor(),
-                        jvmOs,
-                        jvmMemory,
-                        garbageCollectors
-                );
-            } else {
-                jvmInfo = null;
-            }
-
-            final ElasticsearchNodeInfo elasticsearchNodeInfo = ElasticsearchNodeInfo.create(
-                    info.getVersion().toString(),
-                    hostInfo,
-                    jvmInfo
-            );
-
-            elasticsearchNodeInfos.add(elasticsearchNodeInfo);
+        final JsonObject nodesMap = fetchNodeInfos();
+        if (nodesMap == null) {
+            return Collections.emptySet();
         }
+        final Set<ElasticsearchNodeInfo> elasticsearchNodeInfos = Sets.newHashSetWithExpectedSize(nodesMap.entrySet().size());
+        Optional.of(nodesMap)
+                .map(JsonObject::entrySet)
+                .map(Iterable::spliterator)
+                .map(splitr -> StreamSupport.stream(splitr, false))
+                .orElse(Stream.empty())
+                .forEach(entry -> {
+
+                    // TODO remove these as soon as the backend service treats HostInfo as optional
+                    // the host info details aren't available in Elasticsearch 2.x anymore, but we still report the empty
+                    // bean because the backend service still expects some data (even if it is empty)
+                    final MacAddress macAddress = MacAddress.EMPTY;
+                    final HostInfo.Cpu cpu = null;
+                    final HostInfo.Memory memory = null;
+                    final HostInfo.Memory swap = null;
+                    final HostInfo hostInfo = HostInfo.create(macAddress, cpu, memory, swap);
+
+                    final Optional<JsonObject> jvm = Optional.of(entry.getValue())
+                            .map(JsonElement::getAsJsonObject)
+                            .map(nodeInfo -> GsonUtils.asJsonObject(nodeInfo.get("jvm")));
+
+                    final List<String> garbageCollectors = jvm
+                            .map(jvmInfo -> GsonUtils.asJsonArray(jvmInfo.get("gc_collectors")))
+                            .map(Iterable::spliterator)
+                            .map(splitr -> StreamSupport.stream(splitr, false))
+                            .orElse(Stream.empty())
+                            .map(String::valueOf)
+                            .collect(Collectors.toList());
+
+                    final Optional<JsonObject> memInfo = jvm.map(jvmInfo -> GsonUtils.asJsonObject(jvmInfo.get("mem")));
+
+                    final JvmInfo.Memory jvmMemory = JvmInfo.Memory.create(
+                            memInfo.map(mem -> GsonUtils.asLong(mem.get("heap_init_in_bytes"))).orElse(-1L),
+                            memInfo.map(mem -> GsonUtils.asLong(mem.get("heap_max_in_bytes"))).orElse(-1L),
+                            memInfo.map(mem -> GsonUtils.asLong(mem.get("non_heap_init_in_bytes"))).orElse(-1L),
+                            memInfo.map(mem -> GsonUtils.asLong(mem.get("non_heap_max_in_bytes"))).orElse(-1L),
+                            memInfo.map(mem -> GsonUtils.asLong(mem.get("direct_max_in_bytes"))).orElse(-1L)
+                    );
+
+                    final Optional<JsonObject> osInfo = Optional.of(entry.getValue())
+                            .map(JsonElement::getAsJsonObject)
+                            .map(nodeInfo -> GsonUtils.asJsonObject(nodeInfo.get("os")));
+
+                    final JvmInfo.Os jvmOs = JvmInfo.Os.create(
+                            osInfo.map(os -> GsonUtils.asString(os.get("name"))).orElse("<unknown>"),
+                            osInfo.map(os -> GsonUtils.asString(os.get("version"))).orElse("<unknown>"),
+                            osInfo.map(os -> GsonUtils.asString(os.get("arch"))).orElse("<unknown>")
+                    );
+                    final JvmInfo jvmInfo = JvmInfo.create(
+                            jvm.map(j -> GsonUtils.asString(j.get("version"))).orElse("<unknown>"),
+                            jvm.map(j -> GsonUtils.asString(j.get("vm_name"))).orElse("<unknown>"),
+                            jvm.map(j -> GsonUtils.asString(j.get("vm_version"))).orElse("<unknown>"),
+                            jvm.map(j -> GsonUtils.asString(j.get("vm_vendor"))).orElse("<unknown>"),
+                            jvmOs,
+                            jvmMemory,
+                            garbageCollectors
+                    );
+                    final String esVersion = Optional.of(entry.getValue())
+                            .map(JsonElement::getAsJsonObject)
+                            .map(nodeInfo -> GsonUtils.asString(nodeInfo.get("version")))
+                            .orElse("<unknown>");
+
+                    final ElasticsearchNodeInfo elasticsearchNodeInfo = ElasticsearchNodeInfo.create(
+                            esVersion,
+                            hostInfo,
+                            jvmInfo
+                    );
+
+                    elasticsearchNodeInfos.add(elasticsearchNodeInfo);
+                });
 
         return elasticsearchNodeInfos;
     }
@@ -137,15 +146,24 @@ public class ElasticsearchCollector {
         );
     }
 
-    private Map<String, NodeInfo> fetchNodeInfos() {
-        ClusterAdminClient adminClient = this.client.admin().cluster();
-        NodesInfoResponse nodesInfoResponse = adminClient.nodesInfo(adminClient.prepareNodesInfo().request()).actionGet();
-        return nodesInfoResponse.getNodesMap();
-    }
-
-    private Map<String, NodeStats> fetchNodeStats() {
-        ClusterAdminClient adminClient = this.client.admin().cluster();
-        NodesStatsResponse nodesStatsResponse = adminClient.nodesStats(adminClient.prepareNodesStats().request()).actionGet();
-        return nodesStatsResponse.getNodesMap();
+    private JsonObject fetchNodeInfos() {
+        final NodesInfo.Builder requestBuilder = new NodesInfo.Builder()
+                .withHttp()
+                .withJvm()
+                .withNetwork()
+                .withOs()
+                .withPlugins()
+                .withProcess()
+                .withSettings()
+                .withThreadPool()
+                .withTransport();
+        try {
+            final JestResult result = jestClient.execute(requestBuilder.build());
+            return Optional.of(result.getJsonObject())
+                    .map(json -> GsonUtils.asJsonObject(json.get("nodes")))
+                    .orElse(null);
+        } catch (IOException e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Due to the switch to the Elasticsearch HTTP client, we now need to
retrieve the required details of the Elasticsearch cluster nodes on our
own.